### PR TITLE
Add CI from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_install:
 - sudo apt-get -qq install -y cmake
 - if [ "$USE_BLAS" = "TRUE" ]; then sudo apt-get -qq install -y libatlas-base-dev
     ; sudo apt-get -qq install -y libblas-dev
+    ; sudo apt-get -qq install -y liblapack-dev
   ; fi
 - export FC=`which gfortran`
 - $FC --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,17 +21,11 @@ matrix:
     sudo: required
 
 before_install:
-- 'travis_fold:start:gfortran'
 - sudo apt-get -qq install -y gfortran
 - export FC=`which gfortran`
 - $FC --version
-- 'travis_fold:end:gfortran'
-- ''
-- 'travis_fold:start:build_system'
 - sudo apt-get -qq install -y make
 - sudo apt-get -qq install -y cmake
-- 'travis_fold:end:build_system'
-- ''
 - if [ "$USE_BLAS" = "TRUE" ] then sudo apt-get -qq install -y libblas-dev; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
   fast_finish: true
   include:
   - os: linux
-    dist: trusty
+    dist: xenial
     env:
     - USE_BLAS=ON
     sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,5 +37,6 @@ script:
 after_success:
 - for i in BlasBit*; do echo $i
     ; ./$i
+    ; echo ""
   ; done
 - echo "DONE!"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: c
+matrix:
+  fast_finish: true
+  include:
+  - os: linux
+    dist: trusty
+    env:
+    - USE_BLAS=ON
+    sudo: required
+  - os: linux
+    dist: trusty
+    env:
+    - USE_BLAS=OFF
+    - USE_STATIC=ON
+    sudo: required
+  - os: linux
+    dist: trusty
+    env:
+    - USE_BLAS=OFF
+    - USE_STATIC=OFF
+    sudo: required
+
+before_install:
+- 'travis_fold:start:gfortran'
+- sudo apt-get -qq install -y gfortran
+- export FC=`which gfortran`
+- $FC --version
+- 'travis_fold:end:gfortran'
+- ''
+- 'travis_fold:start:build_system'
+- sudo apt-get -qq install -y make
+- sudo apt-get -qq install -y cmake
+- 'travis_fold:end:build_system'
+- ''
+- if [ "$USE_BLAS" = "TRUE" ] then sudo apt-get -qq install -y libblas-dev; fi
+
+script:
+- cmake . -DUSE_BLAS=${USE_BLAS} -DUSE_STATIC=${USE_STATIC}
+- make -j$(nproc)
+
+after_success:
+- for i in BlasBit*; do ./$i; done
+- echo "DONE!"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,8 @@ before_install:
 - sudo apt-get -qq install -y gfortran
 - sudo apt-get -qq install -y make
 - sudo apt-get -qq install -y cmake
-- if [ "$USE_BLAS" = "TRUE" ]
-  ; then
-  ; sudo apt-get -qq install -y libatlas-base-dev
-  ; sudo apt-get -qq install -y libblas-dev
+- if [ "$USE_BLAS" = "TRUE" ]; then sudo apt-get -qq install -y libatlas-base-dev
+    ; sudo apt-get -qq install -y libblas-dev
   ; fi
 - export FC=`which gfortran`
 - $FC --version
@@ -37,9 +35,7 @@ script:
 - make -j$(nproc)
 
 after_success:
-- for i in BlasBit*
-  ; do
-  ; echo $i
-  ; ./$i
+- for i in BlasBit*; do echo $i
+    ; ./$i
   ; done
 - echo "DONE!"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,23 +3,6 @@ matrix:
   fast_finish: true
   include:
   - os: linux
-    dist: precise
-    env:
-    - USE_BLAS=ON
-    sudo: required
-  - os: linux
-    dist: precise
-    env:
-    - USE_BLAS=OFF
-    - USE_STATIC=ON
-    sudo: required
-  - os: linux
-    dist: precise
-    env:
-    - USE_BLAS=OFF
-    - USE_STATIC=OFF
-    sudo: required
-  - os: linux
     dist: trusty
     env:
     - USE_BLAS=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 - $FC --version
 - sudo apt-get -qq install -y make
 - sudo apt-get -qq install -y cmake
-- if [ "$USE_BLAS" = "TRUE" ] then sudo apt-get -qq install -y libblas-dev; fi
+- if [ "$USE_BLAS" = "TRUE" ]; then sudo apt-get -qq install -y libblas-dev ; fi
 
 script:
 - cmake . -DUSE_BLAS=${USE_BLAS} -DUSE_STATIC=${USE_STATIC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,16 +22,24 @@ matrix:
 
 before_install:
 - sudo apt-get -qq install -y gfortran
-- export FC=`which gfortran`
-- $FC --version
 - sudo apt-get -qq install -y make
 - sudo apt-get -qq install -y cmake
-- if [ "$USE_BLAS" = "TRUE" ]; then sudo apt-get -qq install -y libblas-dev ; fi
+- if [ "$USE_BLAS" = "TRUE" ]
+  ; then
+  ; sudo apt-get -qq install -y libatlas-base-dev
+  ; sudo apt-get -qq install -y libblas-dev
+  ; fi
+- export FC=`which gfortran`
+- $FC --version
 
 script:
 - cmake . -DUSE_BLAS=${USE_BLAS} -DUSE_STATIC=${USE_STATIC}
 - make -j$(nproc)
 
 after_success:
-- for i in BlasBit*; do ./$i; done
+- for i in BlasBit*
+  ; do
+  ; echo $i
+  ; ./$i
+  ; done
 - echo "DONE!"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,23 @@ matrix:
   fast_finish: true
   include:
   - os: linux
+    dist: precise
+    env:
+    - USE_BLAS=ON
+    sudo: required
+  - os: linux
+    dist: precise
+    env:
+    - USE_BLAS=OFF
+    - USE_STATIC=ON
+    sudo: required
+  - os: linux
+    dist: precise
+    env:
+    - USE_BLAS=OFF
+    - USE_STATIC=OFF
+    sudo: required
+  - os: linux
     dist: trusty
     env:
     - USE_BLAS=ON
@@ -15,6 +32,40 @@ matrix:
     sudo: required
   - os: linux
     dist: trusty
+    env:
+    - USE_BLAS=OFF
+    - USE_STATIC=OFF
+    sudo: required
+  - os: linux
+    dist: xenial
+    env:
+    - USE_BLAS=ON
+    sudo: required
+  - os: linux
+    dist: xenial
+    env:
+    - USE_BLAS=OFF
+    - USE_STATIC=ON
+    sudo: required
+  - os: linux
+    dist: xenial
+    env:
+    - USE_BLAS=OFF
+    - USE_STATIC=OFF
+    sudo: required
+  - os: linux
+    dist: bionic
+    env:
+    - USE_BLAS=ON
+    sudo: required
+  - os: linux
+    dist: bionic
+    env:
+    - USE_BLAS=OFF
+    - USE_STATIC=ON
+    sudo: required
+  - os: linux
+    dist: bionic
     env:
     - USE_BLAS=OFF
     - USE_STATIC=OFF

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ before_install:
 - sudo apt-get -qq install -y cmake
 - if [ "$USE_BLAS" = "ON" ]; then sudo apt-get -qq install -y libatlas-base-dev
     ; sudo apt-get -qq install -y libblas-dev
-    ; sudo apt-get -qq install -y liblapack-dev
   ; fi
 - export FC=`which gfortran`
 - $FC --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
   fast_finish: true
   include:
   - os: linux
-    dist: xenial
+    dist: trusty
     env:
     - USE_BLAS=ON
     sudo: required
@@ -24,7 +24,7 @@ before_install:
 - sudo apt-get -qq install -y gfortran
 - sudo apt-get -qq install -y make
 - sudo apt-get -qq install -y cmake
-- if [ "$USE_BLAS" = "TRUE" ]; then sudo apt-get -qq install -y libatlas-base-dev
+- if [ "$USE_BLAS" = "ON" ]; then sudo apt-get -qq install -y libatlas-base-dev
     ; sudo apt-get -qq install -y libblas-dev
     ; sudo apt-get -qq install -y liblapack-dev
   ; fi

--- a/BLAS/CMakeLists.txt
+++ b/BLAS/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.9)
 
 project(DDOT_BLAS)
 enable_language(Fortran)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ src/main.F90
 option(USE_BLAS "Linking with BLAS or with DDOT_BLAS" OFF)
 message(STATUS "Linking with BLAS or with DDOT_BLAS: " ${USE_BLAS})
 
+if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-backtrace")
+endif()
+
 if(USE_BLAS)
 
   find_package(BLAS REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.9)
 
 project(BlasBit)
 


### PR DESCRIPTION
This patch
- adds Travis-CI testing;
- downgrades minimal required version of CMake to 3.9;
- removes showing backtrace when GFortran is used.