### PR TITLE
New BLAS subroutine

### DIFF
--- a/BLAS/CMakeLists.txt
+++ b/BLAS/CMakeLists.txt
@@ -4,7 +4,9 @@ project(DDOT_BLAS)
 enable_language(Fortran)
 
 set(SOURCES
-DDOT.F)
+DDOT.F
+IDAMAX.F
+)
 
 if(USE_STATIC)
   add_library(${PROJECT_NAME}32-${LIBRARY_TYPE} STATIC ${SOURCES})

--- a/BLAS/IDAMAX.F
+++ b/BLAS/IDAMAX.F
@@ -1,0 +1,40 @@
+      INTEGER(KIND=IP) FUNCTION IDAMAX(N,DX,INCX)
+      IMPLICIT NONE
+      DOUBLE PRECISION, INTENT(IN) :: DX(*)
+      INTEGER(KIND=IP), INTENT(IN) :: N, INCX
+C
+      INTEGER(KIND=IP) :: I, IX
+      DOUBLE PRECISION :: RMAX
+C
+C     FINDS THE INDEX OF ELEMENT HAVING MAX. ABSOLUTE VALUE.
+C     JACK DONGARRA, LINPACK, 3/11/78.
+C
+      IDAMAX = 0
+      IF( N .LT. 1 ) RETURN
+      IDAMAX = 1
+      IF(N.EQ.1) RETURN
+      IF(INCX.EQ.1)GO TO 20
+C
+C        CODE FOR INCREMENT NOT EQUAL TO 1
+C
+      IX = 1
+      RMAX = ABS(DX(1))
+      IX = IX + INCX
+      DO 10 I = 2,N
+         IF(ABS(DX(IX)).LE.RMAX) GO TO 5
+         IDAMAX = I
+         RMAX = ABS(DX(IX))
+    5    IX = IX + INCX
+   10 CONTINUE
+      RETURN
+C
+C        CODE FOR INCREMENT EQUAL TO 1
+C
+   20 RMAX = ABS(DX(1))
+      DO 30 I = 2,N
+         IF(ABS(DX(I)).LE.RMAX) GO TO 30
+         IDAMAX = I
+         RMAX = ABS(DX(I))
+   30 CONTINUE
+      RETURN
+      END

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ message(STATUS "Linking with BLAS or with DDOT_BLAS: " ${USE_BLAS})
 
 if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-backtrace")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-range-check")
 endif()
 
 if(USE_BLAS)

--- a/src/main.F90
+++ b/src/main.F90
@@ -5,7 +5,7 @@ program main
     ! IDAMAX function from BLAS
     integer(kind=IP) IDAMAX
     ! size of double precision array
-    integer(kind=IP), parameter :: N = 3, STEP = 4294967296
+    integer(kind=IP), parameter :: N = 3, STEP = 4294967297
     ! array
     double precision :: A(N), B(N)
     ! dot product

--- a/src/main.F90
+++ b/src/main.F90
@@ -5,7 +5,7 @@ program main
     ! IDAMAX function from BLAS
     integer(kind=IP) IDAMAX
     ! size of double precision array
-    integer(kind=IP), parameter :: N = 3, STEP = 1
+    integer(kind=IP), parameter :: N = 3, STEP = 4294967296
     ! array
     double precision :: A(N), B(N)
     ! dot product

--- a/src/main.F90
+++ b/src/main.F90
@@ -2,12 +2,16 @@ program main
     implicit none
     ! DDOT function from BLAS
     double precision DDOT
+    ! IDAMAX function from BLAS
+    integer(kind=IP) IDAMAX
     ! size of double precision array
     integer(kind=IP), parameter :: N = 3, STEP = 1
     ! array
     double precision :: A(N), B(N)
     ! dot product
     double precision :: DOT
+    ! idamax value
+    integer(kind=IP) :: DAMAX
     A = (/ 1.0, 2.0, 3.0 /)
     B = (/ 1.0, 2.0, 3.0 /)
     write(6,"(A,I2,A)") "Library: ", LIBRARY, " bit"
@@ -15,4 +19,6 @@ program main
     flush(6)
     DOT = DDOT(N, A, STEP, B, STEP)
     write(6,"(F6.2)") DOT
+    DAMAX = IDAMAX(N,A,STEP)
+    write(6,"(I3)") DAMAX
 end program main


### PR DESCRIPTION
This patch 
- adds new BLAS subroutine IDAMAX
- changes STEP to 2**32 + 1 (for 32 bits libraries, 14 and 3 should be an answer; for 64 bits libraries, the drop should be due to incorrect address)